### PR TITLE
Fix displaying crown on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,7 +121,10 @@ class UI {
     }
 
     // If animation allowed
-    const splitWinnerText = winnerText.split("");
+    const splitWinnerText = winnerText
+      .slice(0, winnerText.indexOf("👑"))
+      .split("")
+      .concat("👑");
 
     this.winnerField.innerText = "";
 


### PR DESCRIPTION
Split method splits crown into 2 different characters. Some mobile browsers are not being able to handle it and display 2 unknown characters instead of crown.